### PR TITLE
Add parse_bytes() and implement all through byte-parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,10 @@ documentation = "https://docs.rs/http-range/0.1.1/http_range/"
 description = "HTTP Range header parser"
 readme = "README.md"
 license = "MIT"
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "benchmark"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+edition = "2018"
 name = "http-range"
 version = "0.1.1"
 authors = ["Luka Zakrajšek <luka@bancek.net>"]

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,0 +1,21 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use http_range::HttpRange;
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("bytes=7", |b| {
+        b.iter(|| HttpRange::parse(black_box("bytes=7"), black_box(10)))
+    });
+    c.bench_function("bytes=-7", |b| {
+        b.iter(|| HttpRange::parse(black_box("bytes=-7"), black_box(10)))
+    });
+    c.bench_function("bytes=500-700,601-999", |b| {
+        b.iter(|| HttpRange::parse(black_box("bytes=500-700,601-999"), black_box(10000)))
+    });
+    c.bench_function("bytes=9500-", |b| {
+        b.iter(|| HttpRange::parse(black_box("bytes=9500-"), black_box(10000)))
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,23 +42,28 @@ impl HttpRange {
 
         let mut no_overlap = false;
 
-        let all_ranges: Vec<Option<HttpRange>> = try!(header[PREFIX_LEN..]
+        let all_ranges: Vec<Option<HttpRange>> = header[PREFIX_LEN..]
             .split(',')
             .map(|x| x.trim())
             .filter(|x| !x.is_empty())
             .map(|ra| {
                 let mut start_end_iter = ra.split('-');
 
-                let start_str =
-                    try!(start_end_iter.next().ok_or(HttpRangeParseError::InvalidRange)).trim();
-                let end_str = try!(start_end_iter.next().ok_or(HttpRangeParseError::InvalidRange))
+                let start_str = start_end_iter
+                    .next()
+                    .ok_or(HttpRangeParseError::InvalidRange)?
+                    .trim();
+                let end_str = start_end_iter
+                    .next()
+                    .ok_or(HttpRangeParseError::InvalidRange)?
                     .trim();
 
                 if start_str.is_empty() {
                     // If no start is specified, end specifies the
                     // range start relative to the end of the file.
-                    let mut length: i64 = try!(end_str.parse()
-                        .map_err(|_| HttpRangeParseError::InvalidRange));
+                    let mut length: i64 = end_str
+                        .parse()
+                        .map_err(|_| HttpRangeParseError::InvalidRange)?;
 
                     if length > size_sig {
                         length = size_sig;
@@ -69,8 +74,9 @@ impl HttpRange {
                         length: length as u64,
                     }))
                 } else {
-                    let start: i64 = try!(start_str.parse()
-                        .map_err(|_| HttpRangeParseError::InvalidRange));
+                    let start: i64 = start_str
+                        .parse()
+                        .map_err(|_| HttpRangeParseError::InvalidRange)?;
 
                     if start < 0 {
                         return Err(HttpRangeParseError::InvalidRange);
@@ -84,8 +90,9 @@ impl HttpRange {
                         // If no end is specified, range extends to end of the file.
                         size_sig - start
                     } else {
-                        let mut end: i64 = try!(end_str.parse()
-                            .map_err(|_| HttpRangeParseError::InvalidRange));
+                        let mut end: i64 = end_str
+                            .parse()
+                            .map_err(|_| HttpRangeParseError::InvalidRange)?;
 
                         if start > end {
                             return Err(HttpRangeParseError::InvalidRange);
@@ -104,7 +111,7 @@ impl HttpRange {
                     }))
                 }
             })
-            .collect::<Result<_, _>>());
+            .collect::<Result<_, _>>()?;
 
         let ranges: Vec<HttpRange> = all_ranges.into_iter().filter_map(|x| x).collect();
 
@@ -125,92 +132,221 @@ mod tests {
     #[test]
     fn test_parse() {
         let tests = vec![
-            T("", 0, vec!()),
-            T("", 1000, vec!()),
-            T("foo", 0, vec!()),
-            T("bytes=", 0, vec!()),
-            T("bytes=7", 10, vec!()),
-            T("bytes= 7 ", 10, vec!()),
-            T("bytes=1-", 0, vec!()),
-            T("bytes=5-4", 10, vec!()),
-            T("bytes=0-2,5-4", 10, vec!()),
-            T("bytes=2-5,4-3", 10, vec!()),
-            T("bytes=--5,4--3", 10, vec!()),
-            T("bytes=A-", 10, vec!()),
-            T("bytes=A- ", 10, vec!()),
-            T("bytes=A-Z", 10, vec!()),
-            T("bytes= -Z", 10, vec!()),
-            T("bytes=5-Z", 10, vec!()),
-            T("bytes=Ran-dom, garbage", 10, vec!()),
-            T("bytes=0x01-0x02", 10, vec!()),
-            T("bytes=         ", 10, vec!()),
-            T("bytes= , , ,   ", 10, vec!()),
-
-            T("bytes=0-9", 10, vec!(
-                HttpRange{start:0, length:10}
-            )),
-            T("bytes=0-", 10, vec!(
-                HttpRange{start:0, length:10}
-            )),
-            T("bytes=5-", 10, vec!(
-                HttpRange{start:5, length:5}
-            )),
-            T("bytes=0-20", 10, vec!(
-                HttpRange{start:0, length:10}
-            )),
-            T("bytes=15-,0-5", 10, vec!(
-                HttpRange{start:0, length:6}
-            )),
-            T("bytes=1-2,5-", 10, vec!(
-                HttpRange{start:1, length:2},
-                HttpRange{start:5, length:5}
-            )),
-            T("bytes=-2 , 7-", 11, vec!(
-                HttpRange{start:9, length:2},
-                HttpRange{start:7, length:4}
-            )),
-            T("bytes=0-0 ,2-2, 7-", 11, vec!(
-                HttpRange{start:0, length:1},
-                HttpRange{start:2, length:1},
-                HttpRange{start:7, length:4}
-            )),
-            T("bytes=-5", 10, vec!(
-                HttpRange{start:5, length:5}
-            )),
-            T("bytes=-15", 10, vec!(
-                HttpRange{start:0, length:10}
-            )),
-            T("bytes=0-499", 10000, vec!(
-                HttpRange{start:0, length:500}
-            )),
-            T("bytes=500-999", 10000, vec!(
-                HttpRange{start:500, length:500}
-            )),
-            T("bytes=-500", 10000, vec!(
-                HttpRange{start:9500, length:500}
-            )),
-            T("bytes=9500-", 10000, vec!(
-                HttpRange{start:9500, length:500}
-            )),
-            T("bytes=0-0,-1", 10000, vec!(
-                HttpRange{start:0, length:1},
-                HttpRange{start:9999, length:1}
-            )),
-            T("bytes=500-600,601-999", 10000, vec!(
-                HttpRange{start:500, length:101},
-                HttpRange{start:601, length:399}
-            )),
-            T("bytes=500-700,601-999", 10000, vec!(
-                HttpRange{start:500, length:201},
-                HttpRange{start:601, length:399}
-            )),
-
+            T("", 0, vec![]),
+            T("", 1000, vec![]),
+            T("foo", 0, vec![]),
+            T("bytes=", 0, vec![]),
+            T("bytes=7", 10, vec![]),
+            T("bytes= 7 ", 10, vec![]),
+            T("bytes=1-", 0, vec![]),
+            T("bytes=5-4", 10, vec![]),
+            T("bytes=0-2,5-4", 10, vec![]),
+            T("bytes=2-5,4-3", 10, vec![]),
+            T("bytes=--5,4--3", 10, vec![]),
+            T("bytes=A-", 10, vec![]),
+            T("bytes=A- ", 10, vec![]),
+            T("bytes=A-Z", 10, vec![]),
+            T("bytes= -Z", 10, vec![]),
+            T("bytes=5-Z", 10, vec![]),
+            T("bytes=Ran-dom, garbage", 10, vec![]),
+            T("bytes=0x01-0x02", 10, vec![]),
+            T("bytes=         ", 10, vec![]),
+            T("bytes= , , ,   ", 10, vec![]),
+            T(
+                "bytes=0-9",
+                10,
+                vec![HttpRange {
+                    start: 0,
+                    length: 10,
+                }],
+            ),
+            T(
+                "bytes=0-",
+                10,
+                vec![HttpRange {
+                    start: 0,
+                    length: 10,
+                }],
+            ),
+            T(
+                "bytes=5-",
+                10,
+                vec![HttpRange {
+                    start: 5,
+                    length: 5,
+                }],
+            ),
+            T(
+                "bytes=0-20",
+                10,
+                vec![HttpRange {
+                    start: 0,
+                    length: 10,
+                }],
+            ),
+            T(
+                "bytes=15-,0-5",
+                10,
+                vec![HttpRange {
+                    start: 0,
+                    length: 6,
+                }],
+            ),
+            T(
+                "bytes=1-2,5-",
+                10,
+                vec![
+                    HttpRange {
+                        start: 1,
+                        length: 2,
+                    },
+                    HttpRange {
+                        start: 5,
+                        length: 5,
+                    },
+                ],
+            ),
+            T(
+                "bytes=-2 , 7-",
+                11,
+                vec![
+                    HttpRange {
+                        start: 9,
+                        length: 2,
+                    },
+                    HttpRange {
+                        start: 7,
+                        length: 4,
+                    },
+                ],
+            ),
+            T(
+                "bytes=0-0 ,2-2, 7-",
+                11,
+                vec![
+                    HttpRange {
+                        start: 0,
+                        length: 1,
+                    },
+                    HttpRange {
+                        start: 2,
+                        length: 1,
+                    },
+                    HttpRange {
+                        start: 7,
+                        length: 4,
+                    },
+                ],
+            ),
+            T(
+                "bytes=-5",
+                10,
+                vec![HttpRange {
+                    start: 5,
+                    length: 5,
+                }],
+            ),
+            T(
+                "bytes=-15",
+                10,
+                vec![HttpRange {
+                    start: 0,
+                    length: 10,
+                }],
+            ),
+            T(
+                "bytes=0-499",
+                10000,
+                vec![HttpRange {
+                    start: 0,
+                    length: 500,
+                }],
+            ),
+            T(
+                "bytes=500-999",
+                10000,
+                vec![HttpRange {
+                    start: 500,
+                    length: 500,
+                }],
+            ),
+            T(
+                "bytes=-500",
+                10000,
+                vec![HttpRange {
+                    start: 9500,
+                    length: 500,
+                }],
+            ),
+            T(
+                "bytes=9500-",
+                10000,
+                vec![HttpRange {
+                    start: 9500,
+                    length: 500,
+                }],
+            ),
+            T(
+                "bytes=0-0,-1",
+                10000,
+                vec![
+                    HttpRange {
+                        start: 0,
+                        length: 1,
+                    },
+                    HttpRange {
+                        start: 9999,
+                        length: 1,
+                    },
+                ],
+            ),
+            T(
+                "bytes=500-600,601-999",
+                10000,
+                vec![
+                    HttpRange {
+                        start: 500,
+                        length: 101,
+                    },
+                    HttpRange {
+                        start: 601,
+                        length: 399,
+                    },
+                ],
+            ),
+            T(
+                "bytes=500-700,601-999",
+                10000,
+                vec![
+                    HttpRange {
+                        start: 500,
+                        length: 201,
+                    },
+                    HttpRange {
+                        start: 601,
+                        length: 399,
+                    },
+                ],
+            ),
             // Match Apache laxity:
-            T("bytes=   1 -2   ,  4- 5, 7 - 8 , ,,", 11, vec!(
-                HttpRange{start:1, length:2},
-                HttpRange{start:4, length:2},
-                HttpRange{start:7, length:2}
-            )),
+            T(
+                "bytes=   1 -2   ,  4- 5, 7 - 8 , ,,",
+                11,
+                vec![
+                    HttpRange {
+                        start: 1,
+                        length: 2,
+                    },
+                    HttpRange {
+                        start: 4,
+                        length: 2,
+                    },
+                    HttpRange {
+                        start: 7,
+                        length: 2,
+                    },
+                ],
+            ),
         ];
 
         for t in tests {
@@ -224,44 +360,44 @@ mod tests {
                 if expected.is_empty() {
                     continue;
                 } else {
-                    assert!(false,
-                            "parse({}, {}) returned error {:?}",
-                            header,
-                            size,
-                            res.unwrap_err());
+                    assert!(
+                        false,
+                        "parse({}, {}) returned error {:?}",
+                        header,
+                        size,
+                        res.unwrap_err()
+                    );
                 }
             }
 
             let got = res.unwrap();
 
             if got.len() != expected.len() {
-                assert!(false,
-                        "len(parseRange({}, {})) = {}, want {}",
-                        header,
-                        size,
-                        got.len(),
-                        expected.len());
+                assert!(
+                    false,
+                    "len(parseRange({}, {})) = {}, want {}",
+                    header,
+                    size,
+                    got.len(),
+                    expected.len()
+                );
                 continue;
             }
 
             for i in 0..expected.len() {
                 if got[i].start != expected[i].start {
-                    assert!(false,
-                            "parseRange({}, {})[{}].start = {}, want {}",
-                            header,
-                            size,
-                            i,
-                            got[i].start,
-                            expected[i].start)
+                    assert!(
+                        false,
+                        "parseRange({}, {})[{}].start = {}, want {}",
+                        header, size, i, got[i].start, expected[i].start
+                    )
                 }
                 if got[i].length != expected[i].length {
-                    assert!(false,
-                            "parseRange({}, {})[{}].length = {}, want {}",
-                            header,
-                            size,
-                            i,
-                            got[i].length,
-                            expected[i].length)
+                    assert!(
+                        false,
+                        "parseRange({}, {})[{}].length = {}, want {}",
+                        header, size, i, got[i].length, expected[i].length
+                    )
                 }
             }
         }


### PR DESCRIPTION
 - Update code to 2018
 - Add benchmark
 - Reduces benchmarked run-time with ~45%
 - Allow parsing directly from http::header::HeaderValue::as_bytes()
