### PR TITLE
When range is a single non-overlapping range, return Err(http_range::HttpRangeParseError::NoOverlap)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ impl HttpRange {
                     .map_err(|_| HttpRangeParseError::InvalidRange)?;
 
                 if start > end {
-                    return Err(HttpRangeParseError::InvalidRange);
+                    return Ok(None);
                 }
 
                 if end >= size {
@@ -207,6 +207,7 @@ mod tests {
             T("bytes=7", 10, vec![]),
             T("bytes= 7 ", 10, vec![]),
             T("bytes=1-", 0, vec![]),
+            T("bytes=100-10", 0, vec![]),
             T("bytes=5-4", 10, vec![]),
             T("bytes=--6", 200, vec![]),
             T("bytes=--0", 200, vec![]),


### PR DESCRIPTION
an http implementer _should_ return a 416 for invalid ranges and _may_ ignore or reject a Range header field that contains an invalid ranges-specifier

Previously this would return `Err(http_range::HttpRangeParseError::InvalidRange)` which makes it impossible for an http implementer to be able to distinguish between an invalid range such as `range: bytes=100-10` and and invalid ranges-specifier such as `range: carrot`, the first _should_ return a 416 and the second _may_ return a 416 or ignore the header.

Note: I couldn't quite understand the test setup, I may have the test incorrect